### PR TITLE
Updating import statement for new version of django-polymorphic.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
     install_requires=[
         'Django>=1.8',
         'django-classy-tags>=0.3.3',
-        # django-polymorphic 0.8 will require different import statements
-        'django-polymorphic>0.2,<0.8',
+        'django-polymorphic>=0.8',
         'jsonfield>=0.9.6'
     ],
     packages=find_packages(exclude=["example", "example.*"]),

--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models.aggregates import Sum
 from django.utils.translation import ugettext_lazy as _
-from polymorphic.polymorphic_model import PolymorphicModel
+from polymorphic.models import PolymorphicModel
 from shop.cart.modifiers_pool import cart_modifiers_pool
 from shop.util.fields import CurrencyField
 from shop.util.loader import get_model_string


### PR DESCRIPTION
An import statement in models_bases/**init**.py was preventing us from
upgrading to django-polymorphic v0.8.0 or later. This import statement
has been fixed and the django-polymorphic requirement in setup.py has
been upgraded.
